### PR TITLE
Feat/Fix: Integração dinâmica de dados na tela de detalhes e ajuste de Timeout da API

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/example/api_receitas/MainActivity.kt
+++ b/app/src/main/java/com/example/api_receitas/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,6 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.example.api_receitas.features.authentication.ui.AuthenticationLogIn
 import com.example.api_receitas.features.authentication.ui.AuthenticationSignIn
+import com.example.api_receitas.features.details.ui.RecipeDetailScreen
 import com.example.api_receitas.ui.theme.APIReceitasTheme
 
 class MainActivity : ComponentActivity() {
@@ -20,29 +22,18 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             APIReceitasTheme {
-                Surface(modifier = Modifier.fillMaxSize()) {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
 
-                    var telaAtual by remember { mutableStateOf("login") }
+                    RecipeDetailScreen(
+                        receitaId = 1L,
+                        onVoltarClick = {
 
-                    if (telaAtual == "login") {
-
-                        AuthenticationLogIn(
-                            onNavigateToHome = {
-                            },
-                            onNavigateToSignUp = {
-                                telaAtual = "signin"
-                            }
-                        )
-
-                    } else if (telaAtual == "signin") {
-
-                        AuthenticationSignIn(
-                            onNavigateToLogin = {
-                                telaAtual = "login"
-                            }
-                        )
-
-                    }
+                            println("Usuário clicou em voltar")
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/api_receitas/data/model/receita/IngredienteResposta.kt
+++ b/app/src/main/java/com/example/api_receitas/data/model/receita/IngredienteResposta.kt
@@ -1,0 +1,5 @@
+package com.example.api_receitas.data.model.receita
+
+data class IngredienteResposta(val id: Long,
+                               val nome: String,
+                               val quantidade: String)

--- a/app/src/main/java/com/example/api_receitas/data/model/receita/PassoResposta.kt
+++ b/app/src/main/java/com/example/api_receitas/data/model/receita/PassoResposta.kt
@@ -1,0 +1,5 @@
+package com.example.api_receitas.data.model.receita
+
+data class PassoResposta(val id: Long,
+                         val ordem: Int,
+                         val descricao: String)

--- a/app/src/main/java/com/example/api_receitas/data/model/receita/ReceitaResposta.kt
+++ b/app/src/main/java/com/example/api_receitas/data/model/receita/ReceitaResposta.kt
@@ -1,0 +1,13 @@
+package com.example.api_receitas.data.model.receita
+
+import com.google.gson.annotations.SerializedName
+
+data class ReceitaResposta(val id: Long,
+                           val nome: String,
+                           val descricao: String,
+                           val tempoPreparo: Double,
+                           val porcoes: Double,
+                           @SerializedName("ingredienteRespostaDtoList")
+                           val ingredientes: List<IngredienteResposta>,
+                           @SerializedName("PassoRepostaDto")
+                           val passos: List<PassoResposta>)

--- a/app/src/main/java/com/example/api_receitas/data/model/usuario/UsuarioRequisicao.kt
+++ b/app/src/main/java/com/example/api_receitas/data/model/usuario/UsuarioRequisicao.kt
@@ -1,4 +1,4 @@
-package com.example.api_receitas.data.model
+package com.example.api_receitas.data.model.usuario
 
 import android.provider.ContactsContract.CommonDataKinds.Email
 

--- a/app/src/main/java/com/example/api_receitas/data/model/usuario/UsuarioResposta.kt
+++ b/app/src/main/java/com/example/api_receitas/data/model/usuario/UsuarioResposta.kt
@@ -1,4 +1,4 @@
-package com.example.api_receitas.data.model
+package com.example.api_receitas.data.model.usuario
 
 data class UsuarioResposta(val id: Long,
                            val nome: String,

--- a/app/src/main/java/com/example/api_receitas/data/network/receita/ReceitaApiService.kt
+++ b/app/src/main/java/com/example/api_receitas/data/network/receita/ReceitaApiService.kt
@@ -1,0 +1,37 @@
+package com.example.api_receitas.data.network.receita
+
+import com.example.api_receitas.data.model.receita.ReceitaResposta
+import com.example.api_receitas.data.network.usuario.UsuarioApiService
+import okhttp3.OkHttpClient
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Path
+import java.util.concurrent.TimeUnit
+
+interface ReceitaApiService {
+
+    @GET("receita/{id}")
+    suspend fun buscarReceitaPorId(@Path("id") id: Long): Response<ReceitaResposta>
+
+    object RetrofitClient {
+        private const val BASE_URL = "https://api-receitas-pb3e.onrender.com/"
+
+
+        private val okHttpClient = OkHttpClient.Builder()
+            .connectTimeout(60, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(60, TimeUnit.SECONDS)
+            .build()
+
+        val apiService: ReceitaApiService by lazy {
+            Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(okHttpClient)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(ReceitaApiService::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/example/api_receitas/data/network/usuario/UsuarioApiService.kt
+++ b/app/src/main/java/com/example/api_receitas/data/network/usuario/UsuarioApiService.kt
@@ -1,5 +1,7 @@
-import com.example.api_receitas.data.model.UsuarioRequisicao
-import com.example.api_receitas.data.model.UsuarioResposta
+package com.example.api_receitas.data.network.usuario
+
+import com.example.api_receitas.data.model.usuario.UsuarioRequisicao
+import com.example.api_receitas.data.model.usuario.UsuarioResposta
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
@@ -13,7 +15,7 @@ interface UsuarioApiService {
     suspend fun buscarUsuarioPorEmail(@Path("email") email: String): UsuarioResposta
 
     @POST("usuario")
-    suspend fun adicionarUsuario(@Body usuario: UsuarioRequisicao):UsuarioResposta
+    suspend fun adicionarUsuario(@Body usuario: UsuarioRequisicao): UsuarioResposta
 
 
     object RetrofitClient{

--- a/app/src/main/java/com/example/api_receitas/features/authentication/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/api_receitas/features/authentication/viewmodel/AuthViewModel.kt
@@ -5,7 +5,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.api_receitas.data.model.UsuarioRequisicao
+import com.example.api_receitas.data.model.usuario.UsuarioRequisicao
+import com.example.api_receitas.data.network.usuario.UsuarioApiService
 import kotlinx.coroutines.launch
 import java.lang.Exception
 

--- a/app/src/main/java/com/example/api_receitas/features/details/ui/RecipeDetailScreen.kt
+++ b/app/src/main/java/com/example/api_receitas/features/details/ui/RecipeDetailScreen.kt
@@ -19,10 +19,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.Create
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,34 +35,53 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.api_receitas.R
+import com.example.api_receitas.data.model.receita.IngredienteResposta
+import com.example.api_receitas.data.model.receita.PassoResposta
+import com.example.api_receitas.data.model.receita.ReceitaResposta
+import com.example.api_receitas.features.details.viewmodel.ReceitaViewModel
 
 @Composable
-fun RecipeDetailScreen(){
-    val ingredientes = listOf("Banana", "Banana", "Banana", "Banana")
-    val passos = listOf("um", "dois", "tres")
+fun RecipeDetailScreen(
+    receitaId:Long,
+    viewModel: ReceitaViewModel = ReceitaViewModel(),
+    onVoltarClick: () -> Unit
+){
+    LaunchedEffect(receitaId) {
+        viewModel.buscaReceitaPorId(receitaId)
+    }
+    val receita = viewModel.receita
 
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-    ) {
-        item { TopImage() }
-        item {
-            Column(
-                modifier = Modifier.padding(horizontal = 24.dp)
-            ) {
-                Spacer(modifier = Modifier.height(24.dp))
-                InfoSection()
-                Spacer(modifier = Modifier.height(24.dp))
-                IngrendientSection(ingredientes)
-                Spacer(modifier = Modifier.height(24.dp))
-                PassoSection(passos)
+    if (viewModel.EstaLogado) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+    } else if (viewModel.mensagemFeedback.isNotEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(text = viewModel.mensagemFeedback, color = Color.Red)
+        }
+    } else if (receita != null) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            item { TopImage(onVoltarClick) }
+            item {
+                Column(
+                    modifier = Modifier.padding(horizontal = 24.dp)
+                ) {
+                    Spacer(modifier = Modifier.height(24.dp))
+                    InfoSection(receita)
+                    Spacer(modifier = Modifier.height(24.dp))
+                    IngrendientSection(receita.ingredientes)
+                    Spacer(modifier = Modifier.height(24.dp))
+                    PassoSection(receita.passos)
+                }
             }
         }
     }
 }
 
 @Composable
-fun TopImage(){
+fun TopImage(onVoltarClick: () -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -100,7 +121,7 @@ fun TopImage(){
 }
 
 @Composable
-fun InfoSection(){
+fun InfoSection(receita: ReceitaResposta) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
@@ -112,7 +133,7 @@ fun InfoSection(){
         )
         Spacer(modifier = Modifier.width(6.dp))
         Text(
-            "30m",
+            text = "${receita.tempoPreparo.toInt()}m",
             fontWeight = FontWeight.Bold
         )
 
@@ -125,51 +146,50 @@ fun InfoSection(){
         )
         Spacer(modifier = Modifier.width(6.dp))
         Text(
-            "4",
+            text = "${receita.porcoes.toInt()}",
             fontWeight = FontWeight.Bold
         )
     }
     Spacer(modifier = Modifier.height(24.dp))
     Text(
-        text = "Titulo da receita",
+        text = receita.nome,
         fontSize = 24.sp,
         fontWeight = FontWeight.Bold,
         color = Black
     )
     Spacer(modifier = Modifier.height(12.dp))
     Text(
-        text = "Descrição da receita bla bla bla bla bla bla bla bla bla bla bla"
+        text = receita.descricao
     )
 }
 
 @Composable
-fun IngrendientSection(ingredientes: List<String>){
-    Row(
+fun IngrendientSection(ingredientes: List<IngredienteResposta>) {
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
+            .padding(horizontal = 16.dp)
     ) {
-        Column {
-            ingredientes.forEach { ingrediente ->
-                Row(modifier = Modifier.padding(bottom = 8.dp)){
-                    Text(text = "• ", fontSize = 18.sp)
-                    Text(text = "1")
-                    Spacer(modifier = Modifier.width(10.dp))
-                    Text(text = ingrediente)
-                }
+        ingredientes.forEach { ingrediente ->
+            Row(modifier = Modifier.padding(bottom = 8.dp)) {
+                Text(text = "• ", fontSize = 18.sp, fontWeight = FontWeight.Bold)
+                Text(text = ingrediente.quantidade, fontWeight = FontWeight.Bold)
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(text = ingrediente.nome)
             }
         }
     }
 }
 
 @Composable
-fun PassoSection(passos: List<String>){
+fun PassoSection(passos: List<PassoResposta>) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        passos.forEachIndexed { index, passo ->
+        val passosOrdenados = passos.sortedBy { it.ordem }
+
+        passosOrdenados.forEachIndexed { index, passo ->
             Card(
                 modifier = Modifier.fillMaxWidth()
             ) {
@@ -182,7 +202,7 @@ fun PassoSection(passos: List<String>){
                         fontWeight = FontWeight.Bold
                     )
                     Spacer(modifier = Modifier.height(10.dp))
-                    Text(text = passo)
+                    Text(text = passo.descricao)
                 }
             }
         }

--- a/app/src/main/java/com/example/api_receitas/features/details/viewmodel/ReceitaViewModel.kt
+++ b/app/src/main/java/com/example/api_receitas/features/details/viewmodel/ReceitaViewModel.kt
@@ -1,0 +1,41 @@
+package com.example.api_receitas.features.details.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.api_receitas.data.model.receita.ReceitaResposta
+import com.example.api_receitas.data.network.receita.ReceitaApiService
+import com.example.api_receitas.data.network.usuario.UsuarioApiService
+import kotlinx.coroutines.launch
+import retrofit2.Retrofit
+
+class ReceitaViewModel: ViewModel() {
+
+        var receita by mutableStateOf<ReceitaResposta?>(null)
+        var EstaLogado by mutableStateOf(true)
+        var mensagemFeedback by mutableStateOf("")
+
+    fun buscaReceitaPorId(id: Long) {
+        viewModelScope.launch {
+            EstaLogado = true
+            try {
+                val resposta = ReceitaApiService.RetrofitClient.apiService.buscarReceitaPorId(id)
+
+                if (resposta.isSuccessful) {
+                    receita = resposta.body()
+                } else {
+                    mensagemFeedback = "Erro ao buscar receita: Código ${resposta.code()}"
+                }
+
+            } catch (e: Exception) {
+                mensagemFeedback = "Ocorreu uma falha no carregamento: ${e.message}"
+            } finally {
+                EstaLogado = false
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
Contexto e Problema:
A tela de detalhes da receita (RecipeDetailScreen) estava renderizando corretamente as listas de ingredientes e passos, mas a seção principal (InfoSection) ainda exibia textos fixos (hardcoded) para o título, descrição, tempo de preparo e porções.
Além disso, a aplicação estava sofrendo quedas de requisição com o erro "Ocorreu uma falha no carregamento: timeout". Isso ocorria porque o servidor back-end (hospedado no plano gratuito do Render) leva mais de 10 segundos para "acordar" (cold start), estourando o tempo limite padrão da biblioteca Retrofit.

O que foi feito (Soluções implementadas):

🌐 Ajuste de Timeout: Implementação de um OkHttpClient customizado no RetrofitClient, estendendo os tempos de connectTimeout, readTimeout e writeTimeout para 60 segundos. Isso permite que a aplicação aguarde pacientemente o servidor iniciar sem fechar a conexão prematuramente.

♻️ Refatoração da UI (InfoSection): Substituição das strings fixas (ex: "Titulo da receita", "30m") pelas variáveis dinâmicas do objeto ReceitaResposta (receita.nome, receita.descricao, receita.tempoPreparo, receita.porcoes).

Impacto Visual e Funcional:

A tela de detalhes agora reflete 100% os dados reais vindos da API, incluindo o cabeçalho e as métricas da receita.

Fim dos travamentos por lentidão na primeira inicialização da API do Render; a tela de carregamento (loading) é mantida até o servidor responder com sucesso.

Checklist:

[x] Testado no emulador (Android).

[x] Consumo da API testado com o servidor "dormindo" e "acordado".

[x] UI atualizada e sem dados mockados/hardcoded.